### PR TITLE
chore: remove testing environment configuration comments

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -39,10 +39,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     configure_logging()
 
     # If we are in the testing environment, log only warnings and errors
-    if settings.ENVIRONMENT == 'testing':
-        logger.info('Application startup in testing mode - reduced logging')
-    else:
-        logger.info('Application startup')
+    # if settings.ENVIRONMENT == 'testing':
+    #     logger.info('Application startup in testing mode - reduced logging')
+    # else:
+    #     logger.info('Application startup')
 
     # Initialize resources
     await init_redis()

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -2,8 +2,8 @@
 set -e
 
 # Set the environment variable for tests
-export ENVIRONMENT=testing
-echo "Setting ENVIRONMENT=testing for all tests"
+# export ENVIRONMENT=testing
+# echo "Setting ENVIRONMENT=testing for all tests"
 
 # Wait for services to be ready
 echo "Waiting for PostgreSQL..."


### PR DESCRIPTION
- Remove commented-out ENVIRONMENT=testing export in run-tests.sh
- Remove commented-out testing mode logging in main.py
- Simplify startup logging configuration