### PR TITLE
feat: Enhance Project Print Form with Equipment Category Grouping

### DIFF
--- a/backend/schemas/project.py
+++ b/backend/schemas/project.py
@@ -158,6 +158,8 @@ class EquipmentPrintItem(BaseModel):
     serial_number: Optional[str] = None
     liability_amount: float = 0.0
     quantity: int = 1
+    category_id: Optional[int] = None
+    category_name: Optional[str] = None
 
     model_config = ConfigDict(
         from_attributes=True,

--- a/frontend/static/css/print.css
+++ b/frontend/static/css/print.css
@@ -218,6 +218,19 @@ body {
     text-align: right;
 }
 
+/* Category separator row */
+.category-separator td {
+    padding-top: 0.4em !important; /* Add space above separator */
+    padding-bottom: 0.1em !important;
+    border-bottom: 1px solid #999 !important; /* Make separator line slightly darker */
+    background-color: #f8f8f8 !important; /* Light background for separator */
+    font-weight: bold;
+    color: #333;
+    page-break-before: auto; /* Allow break before if needed */
+    page-break-after: avoid; /* Try to keep with first item */
+    break-inside: avoid;
+}
+
 /* Footer styles */
 .print-footer {
     margin-top: 0.3cm;

--- a/frontend/templates/print/project.html
+++ b/frontend/templates/print/project.html
@@ -56,13 +56,20 @@
                 </thead>
                 <tbody>
                     {% for item in equipment %}
-                    <tr>
-                        <td class="col-num">{{ loop.index }}</td>
-                        <td class="col-name">{{ item.name }}</td>
-                        <td class="col-serial">{{ item.serial_number or "—" }}</td>
-                        <td class="col-qty">{{ item.quantity or 1 }}</td>
-                        <td class="col-amount">{{ (item.liability_amount * item.quantity) | format_currency }}</td>
-                    </tr>
+                        {# Print category separator if category changes or it's the first item #}
+                        {% if loop.first or item.category_name != loop.previtem.category_name %}
+                        <tr class="category-separator">
+                            <td colspan="5"><strong>{{ item.category_name or 'Без категории' }}</strong></td>
+                        </tr>
+                        {% endif %}
+                        {# Original item row #}
+                        <tr>
+                            <td class="col-num">{{ loop.index }}</td>
+                            <td class="col-name">{{ item.name }}</td>
+                            <td class="col-serial">{{ item.serial_number or "—" }}</td>
+                            <td class="col-qty">{{ item.quantity or 1 }}</td>
+                            <td class="col-amount">{{ (item.liability_amount * item.quantity) | format_currency }}</td>
+                        </tr>
                     {% endfor %}
                 </tbody>
                 <tfoot>


### PR DESCRIPTION
# Enhance Project Print Form with Equipment Category Grouping

![PR Status](https://img.shields.io/badge/status-ready%20for%20review-brightgreen)
![Feature Area](https://img.shields.io/badge/area-Project%20Print-blue)
![UX Improvement](https://img.shields.io/badge/UX-improved%20readability-brightgreen)

## 🔍 Overview

This Pull Request enhances the project print form (`/projects/{project_id}/print`) by grouping the listed equipment items by their respective categories. This improves the structure, readability, and overall organization of the printed document, making it easier to review the equipment involved in a project.

## Key Changes

<details>
<summary>📄 Backend Schema & Logic Update</summary>

- **Schema Enhancement:**
  - The `EquipmentPrintItem` Pydantic schema (`backend/schemas/project.py`) has been updated to include `category_id` and `category_name` fields.
- **Data Fetching & Sorting:**
  - The `print_project` web route (`backend/web/routes/projects.py`) now explicitly fetches the category information for each piece of equipment associated with the project's bookings.
  - **Crucially, the list of equipment items (`equipment_items`) is now sorted alphabetically first by `category_name` and then by equipment `name` before being passed to the template.** This ensures correct grouping in the output.

</details>

<details>
<summary>📑 Frontend Template Update (print/project.html)</summary>

- **Category Grouping Logic:**
  - The Jinja2 loop iterating through the `equipment` list in `frontend/templates/print/project.html` has been modified.
  - It now checks if the current item's `category_name` differs from the previous item's category (or if it's the first item in the loop).
  - When a category change is detected, a new table row (`<tr class="category-separator">`) is inserted, displaying the category name as a header for the group.
- **Display:**
  - Items without a category are grouped under "Без категории".

</details>

<details>
<summary>🎨 CSS Styling (print.css)</summary>

- **Separator Styling:**
  - Added specific CSS rules for the `.category-separator` class in `frontend/static/css/print.css`.
  - These styles add padding, a slightly darker bottom border, a light background, and bold text to visually distinguish the category headers within the equipment table.
  - Includes `page-break-after: avoid;` and `break-inside: avoid;` to try and keep the separator with the first item of its group when printing.

</details>

## 💡 Impact

- **Improved Readability:** The equipment list on the printed form is now much easier to read and scan, as related items are grouped together.
- **Better Organization:** Provides a clear structure based on equipment categories, reflecting how equipment is often managed.
- **Enhanced Professionalism:** The grouped list presents a more organized and professional-looking document for clients and internal use.

## ✅ Checklist

- [x] `EquipmentPrintItem` schema includes category information.
- [x] Backend route fetches category data for equipment.
- [x] Equipment list is correctly sorted by category, then name.
- [x] Print template correctly inserts category separator rows.
- [x] CSS styles visually distinguish category separators.
- [x] Tested print output for correct grouping and appearance.

---

<details>
<summary>📋 View commit</summary>

- `feat: group equipment by category in project print form`
</details>