### PR TITLE
Fix: Install uv from PyPI Instead of astral.sh Shell Installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,14 +34,12 @@ RUN if [ -f "docker/pip.conf" ]; then mkdir -p /etc/pip && cp docker/pip.conf /e
 # ARG to control environment type
 ARG ENV_TYPE=prod
 
-# Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    echo 'export PATH="/root/.local/bin:$PATH"' >> ~/.bashrc && \
-    export PATH="/root/.local/bin:$PATH"
+# Install uv from PyPI (more reliable than astral.sh shell installer,
+# which silently succeeds when piped to sh on TLS/network failure)
+RUN pip install --no-cache-dir uv
 
 # Install dependencies based on environment type
-RUN export PATH="/root/.local/bin:$PATH" && \
-    uv pip install --system . && \
+RUN uv pip install --system . && \
     uv pip install --system psycopg2-binary && \
     if [ "$ENV_TYPE" = "dev" ]; then \
         echo "Installing development-specific dependencies (e.g., faker for seeding)..." && \
@@ -55,7 +53,6 @@ RUN export PATH="/root/.local/bin:$PATH" && \
 # Install Playwright if needed
 ARG INSTALL_PLAYWRIGHT=false
 RUN if [ "$INSTALL_PLAYWRIGHT" = "true" ]; then \
-        export PATH="/root/.local/bin:$PATH" && \
         uv pip install --system playwright && \
         playwright install chromium; \
     fi

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -54,9 +54,9 @@ RUN apt-get update && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    echo 'export PATH="/root/.local/bin:$PATH"' >> ~/.bashrc
+# Install uv from PyPI (more reliable than astral.sh shell installer,
+# which silently succeeds when piped to sh on TLS/network failure)
+RUN pip install --no-cache-dir uv
 
 # Copy requirements and source code
 COPY requirements.txt .
@@ -69,10 +69,8 @@ COPY tests/ ./tests/
 
 
 # Install Python dependencies
-RUN export PATH="/root/.local/bin:$PATH" && \
-    uv pip install --system .
-RUN export PATH="/root/.local/bin:$PATH" && \
-    uv pip install --system \
+RUN uv pip install --system .
+RUN uv pip install --system \
     pytest==7.4.0 \
     pytest-asyncio==0.21.1 \
     pytest-cov==4.1.0 \
@@ -90,8 +88,7 @@ RUN export PATH="/root/.local/bin:$PATH" && \
 COPY docker/ ./docker/
 
 # Install Playwright browser
-RUN export PATH="/root/.local/bin:$PATH" && \
-    playwright install chromium
+RUN playwright install chromium
 
 # Make scripts executable
 RUN chmod +x docker/wait-for.sh docker/run-tests.sh


### PR DESCRIPTION
# Fix: Install uv from PyPI Instead of astral.sh Shell Installer

![PR Status](https://img.shields.io/badge/status-ready%20for%20review-brightgreen)
![Feature Area](https://img.shields.io/badge/area-DevOps%20|%20Docker-blue)
![Feature Type](https://img.shields.io/badge/type-bugfix%20|%20hardening-red)
![Stack](https://img.shields.io/badge/stack-Docker%20|%20Python-orange)

## 🚀 Overview

Fixes a silent build failure where `curl https://astral.sh/uv/install.sh | sh` returns exit code 0 even when curl fails with a TLS error — leaving `uv` uninstalled and causing the next RUN step to fail with `uv: not found` (exit 127). Reproduced on a production machine where network conditions block `astral.sh`.

**2 files changed, 10 insertions, 16 deletions.**

## 🐛 Root Cause

Observed on the production machine ([build_diagnostic.log](logs/fromprod/build_diagnostic.log)):

```
#15 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && ...
#15 147.4 curl: (35) TLS connect error: error:0A000126:SSL routines::unexpected eof while reading
#15 DONE 147.4s   ← layer cached as success!
#16 0.310 /bin/sh: 1: uv: not found   ← exit 127
```

The `curl ... | sh` idiom has a well-known trap: when the curl process fails, the pipe's exit code is `sh`'s exit code. `sh` receives an empty/truncated stream, does nothing, and exits 0. Docker caches the layer as "DONE", and only the next RUN step reveals the problem.

## 🎯 Key Changes

<details>
<summary><b>Replace shell installer with `pip install uv`</b></summary>

PyPI is substantially more resilient than `astral.sh` (especially on networks with TLS MITM, strict firewalls, or geographic restrictions), `pip install` returns a proper non-zero exit code on failure, and the existing `PIP_INDEX_URL` / `docker/pip.conf` hooks allow deployments to point at a mirror without touching the Dockerfile.

**Before:**
```dockerfile
RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
    echo 'export PATH="/root/.local/bin:$PATH"' >> ~/.bashrc && \
    export PATH="/root/.local/bin:$PATH"

RUN export PATH="/root/.local/bin:$PATH" && \
    uv pip install --system . && \
    ...
```

**After:**
```dockerfile
RUN pip install --no-cache-dir uv

RUN uv pip install --system . && \
    ...
```

`uv` installed via pip lands in `/usr/local/bin/` which is already in PATH, so all the `export PATH="/root/.local/bin:$PATH"` lines scattered across RUN steps become unnecessary and are removed.

</details>

<details>
<summary><b>Same fix in Dockerfile.test</b></summary>

`Dockerfile.test` uses the same `curl | sh` pattern. Applied the identical fix so the test image is equally robust.

</details>

## 📁 Changed Files

| File | Changes | Description |
|------|---------|-------------|
| `Dockerfile` | Fix | Replace curl shell installer with `pip install uv`, drop redundant PATH exports |
| `Dockerfile.test` | Fix | Same fix applied to the test image |

## 🔍 Why This Is Better for Restricted Networks

1. **PyPI has better geographic coverage** — served via Fastly CDN with Russian PoPs; `astral.sh` is a single origin.
2. **Existing mirror support** — `PIP_INDEX_URL` env var and `docker/pip.conf` hook already in the Dockerfile let deployments redirect to mirrors like `https://mirror.sberedu.ru/pypi/` without code changes.
3. **Explicit failures** — `pip install` exits non-zero on network failure, instead of silently producing a broken image.

## 🧪 Test Plan

- [x] Pre-commit hooks pass
- [ ] Build succeeds on production machine where `astral.sh` was failing
- [ ] `uv --version` prints a version in the final image
- [ ] `make test` still works against updated Dockerfile.test
- [ ] No regression in dev build (`docker compose build`)

## 📝 Note

This PR is **independent** of #141 (date year 0026 fix + docker port configurability). Either can merge first. No version bump here — version will be incremented by whichever PR merges second, or in a follow-up commit.