### PR TITLE
chore(deps): drop redundant dependabot entry, bump launcher pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,23 +16,3 @@ updates:
       separator: "/"
     assignees:
       - "NewalexOA"
-
-  # The macOS launcher pins its own dependencies and is not covered by the
-  # root entry above, so updates for it were never proposed.
-  - package-ecosystem: "pip"
-    directory: "/ACT-Rental-Launcher"
-    schedule:
-      interval: "weekly"
-    target-branch: "develop"
-    labels:
-      - "dependencies"
-      - "python"
-      - "launcher"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    open-pull-requests-limit: 5
-    pull-request-branch-name:
-      separator: "/"
-    assignees:
-      - "NewalexOA"

--- a/ACT-Rental-Launcher/requirements.txt
+++ b/ACT-Rental-Launcher/requirements.txt
@@ -1,4 +1,4 @@
-PyQt5==5.15.10
-py2app==0.28.8
+PyQt5==5.15.11
+py2app==0.28.10
 setuptools==83.0.0
-wheel==0.46.2
+wheel==0.47.0


### PR DESCRIPTION
Corrects a mistake from #154 and consolidates the launcher updates it caused.

## The redundant config entry

#154 added a `/ACT-Rental-Launcher` entry to `dependabot.yml` on the premise that the launcher was not covered. **That premise was wrong.** The root `directory: "/"` entry scans requirements files recursively and has always covered it — PR #131 updated the launcher's `wheel` pin back in January. Its `setuptools` pin was a year out of date because those PRs kept being closed, not because none were opened.

The consequence was visible immediately: every launcher package got two pull requests against the same file — #156/#168 for `pyqt5`, #157/#166 for `wheel`, #158/#159 for `py2app`.

This removes the entry.

## Launcher pins bumped here rather than merged individually

- `PyQt5` 5.15.10 → 5.15.11
- `py2app` 0.28.8 → 0.28.10
- `wheel` 0.46.2 → 0.47.0

All three Dependabot pairs touch the same file, so merging them one at a time would put each remaining PR into conflict and wait on a rebase between every merge. Applying them in one commit produces identical content in one step. The six PRs are closed as superseded.

## Note

These pins belong to the macOS launcher, which is a PyQt5 application built with py2app and is not exercised by the test suite. The bumps are patch-level and low risk, but they are verified by nothing beyond that — the launcher should be built once before relying on it.
